### PR TITLE
Fixes #35: Adds support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+dist: trusty
+language: ruby
+
+cache:
+  bundler: true
+
+rvm:
+  - 2.3.3
+
+install:
+  - bundle install
+
+script:
+  - bundle exec jekyll build
+
+branches:
+  only:
+    - gh-pages
+    - /./  # Allows builds for any other branch

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FOSSASIA GCI 2017 Site
 
+[![Build Status](https://travis-ci.org/fossasia/gci17.fossasia.org.svg)](https://travis-ci.org/fossasia/gci17.fossasia.org)
+
 # Adding a mentor
 
 To add a mentor open the file `mentors.yml` in `_data` folder and please maintain the following format *EXACTLY* (replacing values where indicated):


### PR DESCRIPTION
Travis CI can be used to test code and make sure that the code works well.
Adds .travis.yml and Gemfile. Travis will build Jekyll as this site is being hosted on Jekyll.

Fixes #35 

Screenshot:

![screenshot_2017-12-01-12-18-44-858_com android chrome](https://user-images.githubusercontent.com/8947010/33471144-e514e1aa-d691-11e7-9ff1-4a06ca0b678b.png)

For mentors: Please turn on travis ci building for this repo in the Travis ci dashboard. I don't have write access, that's why.