### PR TITLE
index.html: changes fixes typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
                                                     </a>
                                                 {% endif %}
                                                 {% if mentor.facebook %}
-                                                    <a href="https://facebook.com/{{mentor.github}}" class="icon-a">
+                                                    <a href="https://facebook.com/{{mentor.facebook}}" class="icon-a">
                                                        <i class="ti-facebook icon-i"></i>
                                                     </a>
                                                 {% endif %}


### PR DESCRIPTION
{{ mentor.github }} should have been {{mentor.facebook}} in the
href of the fb icon of the mentor.

Fixes #76 