### PR TITLE
Fix FOSSASIA's logo reference link on nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,7 +24,7 @@
 			<nav>
 				<div class="nav-bar">
 					<div class="module left">
-						<a href="index.html">
+						<a href="https://fossasia.org/">
 							<img class="logo logo-dark" alt="FOSSASIA" src="img/fossasia-dark.png" width="110px" height="18.69">
 						</a>
 					</div>


### PR DESCRIPTION
Closes #218 
- [x] Read and understood (see CONTRIBUTING.md)
- [x] Included a live link or preview screenshot
- [x] Images are `240 x 240` [w x h]
- [x] Resolved merge conflicts
- [x] Included a description of my change below

# Things done in this Pull Request

- Fix logo's reference link as per #218 which is already solved, this was accidentally skipped.

https://anshumanv.github.io/gci17.fossasia.org/