### PR TITLE
Fixes #411: Added animations, renamed repos.html

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -50,7 +50,7 @@
 		                            <a href="{{ baseurl }}./#projects">Projects</a>
 		                        </li>
 		                        <li>
-		                            <a href="{{ baseurl }}./repos.html">Repositories</a>
+		                            <a href="{{ baseurl }}./repositories.html">Repositories</a>
 		                        </li>
 		                        <li>
 									<a href="{{ baseurl }}./#map-sec">Map</a>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 							Participate in Google Codein with <b>FOSSASIA</b> !
 						</p>
 						<a class="btn btn-lg btn-filled" href="https://codein.withgoogle.com/organizations/fossasia/">Take me Along !</a>
-						<a class="btn btn-lg" href="repos.html">Explore the site</a>
+						<a class="btn btn-lg" href="repositories.html">Explore the site</a>
 					</div>
 				</div>
 			</div>

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -32,7 +32,7 @@ $(document).ready(function(){
   }).done(function(data) {
     shuffle(data)
     data.forEach(function(repos){
-      var html = '<div class="card hvr-hang revealOnScroll single-mentor aos-all aos-item" data-aos="fade-down-right">';
+      var html = '<div class="card hvr-hang revealOnScroll single-mentor aos-all aos-item" data-aos="flip-left">';
       html += '<img src="https://github.com/'+repos.owner.login+'.png?size=240x240" height="240" width="240">';
       html += '<br>';
       html += '<p class="person-name">'+repos.name+' ('+repos.open_issues;

--- a/repositories.html
+++ b/repositories.html
@@ -1,5 +1,5 @@
 ---
-permalink: repos
+permalink: repositories
 ---
 
 {% include header.html %}


### PR DESCRIPTION
# Fixes #411

- [x] Read and understood (see CONTRIBUTING.md)
- [x] Included a live link or preview screenshot
- [ ] Images are `240 x 240` [w x h]
- [x] Resolved merge conflicts
- [x] Included a description of my change below

# Things done in this Pull Request

- ### Added new Animations, renamed `repos.html` to `repositories.html`

- **Preview Animations : https://0x48piraj.github.io/gci17.fossasia.org/repositories.html**
- **Preview Linking - https://0x48piraj.github.io/gci17.fossasia.org**
![image](https://user-images.githubusercontent.com/5800726/34276335-f79d3c42-e6c6-11e7-9b6a-69a7085776d5.png)

Click on **Explore the site** :+1: 