### PR TITLE
Replaced static messy images to fully responsive flicker-powered gallery :fire:

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,13 +495,7 @@
 
 <!-- placeholder flickr feed -->
 <section>
-	<div class="container">
-		<div class="row">
-			<div class="col-sm-12">
-				<ul class="flickr-feed masonry masonryFlyIn" data-user-id="45240298@N08" data-album-id="72157665486359899"></ul>
-			</div>
-		</div>
-	</div>
+<div id="flickrembed"></div><div style="position:absolute; top:-70px; display:block; text-align:center; z-index:-1;"><a href="https://youtubevideoembed.com">Embed Youtube</a></div><script src='https://flickrembed.com/embed_v2.js.php?source=flickr&layout=responsive&input=72157665486359899&sort=0&by=album&theme=default&scale=fill&limit=10&skin=default-light&autoplay=true'></script><small style="display: block; text-align: center; margin: 0 auto;">Powered by <a href="https://github.com/0x48piraj">flickr | 0x48piraj</a>.</small>
 </section>
 
 


### PR DESCRIPTION
# Fixes #448
![image](https://user-images.githubusercontent.com/5800726/34323184-3da78542-e863-11e7-81e2-2c33c15d94e5.png)

- [x] Read and understood (see CONTRIBUTING.md)
- [x] Included a live link or preview screenshot
- [ ] Images are `240 x 240` [w x h]
- [x] Resolved merge conflicts
- [x] Included a description of my change below

# Things done in this Pull Request


- Removed old picture setup fully.
- Implemented a fully new responsive **flicker-api-powered** gallery with **Youtube API** integration :fire::fire:
- **_Preview - https://0x48piraj.github.io/gci17.fossasia.org/_**

![gallery-demo](https://user-images.githubusercontent.com/5800726/34323193-8779b9a6-e863-11e7-8d3e-e56da577a5c4.gif)
