### PR TITLE
Adds missing dependency

### DIFF
--- a/installation/installation_linux(pl).md
+++ b/installation/installation_linux(pl).md
@@ -3,7 +3,7 @@
 Instrukcje na tej stronie przeprowadzą Cię przez proces konfiguracji lokalnego środowiska programistycznego w Linuksie.
 
 ### Instalacja Ruby
-1. Otwórz Terminal i użyj package managera aby zainstalować Ruby. Na przykład, dla Ubuntu lub Debiana użyj `sudo apt-get install ruby` a dla Arch Linux `sudo pacman -S ruby`.
+1. Otwórz Terminal i użyj package managera aby zainstalować Ruby. Na przykład, dla Ubuntu lub Debiana użyj `sudo apt-get install ruby ruby-dev` a dla Arch Linux `sudo pacman -S ruby ruby-dev`.
 2. Aby gemy były wykonywalne użyj `(ruby -e 'print Gem.user_dir')` następnie `PATH="$(ruby -e 'print Gem.user_dir')/bin:$PATH"` i w końcu `export GEM_HOME=$HOME/.gem`.(więcej informacji `https://wiki.archlinux.org/index.php/ruby#Setup`)
 
 ### Instalacja jekyll

--- a/installation/installation_linux(sin).md
+++ b/installation/installation_linux(sin).md
@@ -3,7 +3,7 @@
 මෙම පිටුවෙහි ඇති උපදෙස් ඔබට ලිනක්ස් පාරිසරිකය තුල ප්‍රාදේශීය ප්‍රවර්ධන සැකසුමට මග පෙන්වනු ඇත. 
 
 ### Ruby ස්ථාපනය කිරීම  
-1. ටර්මිනල් එකක් විවෘත කර ruby ස්ථාපනය කිරීම සඳහා ඇසුරුම් කළමණාකරු භාවිතා කරන්න. නිදසුනක් ලෙස, Ubuntu or Debian භාවිතා කර `sudo apt-get install ruby` හෝ Arch Linux මත `sudo pacman -S ruby` හෝ භාවිතා කරන්න
+1. ටර්මිනල් එකක් විවෘත කර ruby ස්ථාපනය කිරීම සඳහා ඇසුරුම් කළමණාකරු භාවිතා කරන්න. නිදසුනක් ලෙස, Ubuntu or Debian භාවිතා කර `sudo apt-get install ruby ruby-dev` හෝ Arch Linux මත `sudo pacman -S ruby ruby-dev` හෝ භාවිතා කරන්න
 2. ක්‍රියාත්මක කළ හැකි gems වර්ගයක් සැකසීම සඳහා `(ruby -e 'print Gem.user_dir')` අනතුරුව `PATH="$(ruby -e 'print Gem.user_dir')/bin:$PATH"` ඒ වගේම අවසානයට `export GEM_HOME=$HOME/.gem` ලියනය කරන්න.(වැඩි දුර විස්තර මෙතැන `https://wiki.archlinux.org/index.php/ruby#Setup`)
 
 ### jekyll ස්ථාපනය කිරීම

--- a/installation/installation_linux.md
+++ b/installation/installation_linux.md
@@ -4,7 +4,7 @@ The instructions on this page will guide you in setting up a local development
 environment in Linux.
 
 ### Ruby Installation
-1. Open a Terminal and use a package manager to install ruby. For example, on Ubuntu or Debian use `sudo apt-get install ruby` or on Arch Linux `sudo pacman -S ruby`.
+1. Open a Terminal and use a package manager to install ruby. For example, on Ubuntu or Debian use `sudo apt-get install ruby ruby-dev` or on Arch Linux `sudo pacman -S ruby ruby-dev`.
 2. To make gems executable type `(ruby -e 'print Gem.user_dir')` then `PATH="$(ruby -e 'print Gem.user_dir')/bin:$PATH"` and last `export GEM_HOME=$HOME/.gem`.(more info at `https://wiki.archlinux.org/index.php/ruby#Setup`)
 
 ### jekyll Installation


### PR DESCRIPTION
`ruby-dev` is required to install Jekyll.
This PR adds missing `ruby-dev` dependency to linux installation guides.

Please read and understand everything below
**Do not delete any text other than where you are instructed.**

**Students: If one of them is applicable to you. Please check it.**

Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.

- [x] Read and understood (see CONTRIBUTING.md)
- [ ] Included a Preview link and screenshot showning after and before the changes.
- [ ] Images are `240 x 240` [w x h].
- [x] Included a description of change below.
- [ ] Squashed the commits.

# Changes done in this Pull Request

- If your change will be reflected on the website, please provide a **Test-Link** (**Hint : `gh-pages`**)
- Fixes #689 
