### PR TITLE
Drop-down arrow shows with GCI icon

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>Google Code-In with FOSSASIA 2017/18</title>	
+  <title>Google Code-In with FOSSASIA 2017/18</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta HTTP-EQUIV="Access-Control-Allow-Origin" content="https://code.jquery.com">
 	<link href="css/bootstrap.css" rel="stylesheet" type="text/css" media="all" />
@@ -12,12 +12,12 @@
 	<link href="css/animate.css" rel="stylesheet" type="text/css" media="all" />
 	<link href="css/hover.css" rel="stylesheet" type="text/css" media="all" />
 	<link href="css/custom.css" rel="stylesheet" type="text/css" media="all" />
-	<link href="css/blog.css" rel="stylesheet" type="text/css" media="all" />	
+	<link href="css/blog.css" rel="stylesheet" type="text/css" media="all" />
 	<link href="css/hover-media-links.css" rel="stylesheet" type="text/css" media="all">
 	<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all">
 	<link href='https://fonts.googleapis.com/css?family=Lato:300,400%7CRaleway:100,400,300,500,600,700%7COpen+Sans:400,500,600' rel='stylesheet' type='text/css'>
 	<link rel="icon" href="favicon.ico" />
-	
+
 	<link rel="manifest" href="{{ "/manifest.json" | relative_url }}">
 </head>
 
@@ -38,10 +38,10 @@
 						<ul class="menu">
 							<li>
 								<a href="{{ baseurl }}./#welcome">Welcome</a>
-							</li>	                    
+							</li>
      						<li>
 								<a href="{{ baseurl }}./#mentors">Mentors</a>
-							</li>  
+							</li>
 							<li>
 								<a href="{{ baseurl }}./#students">Students</a>
 							</li>
@@ -69,8 +69,8 @@
 										<a href="{{ baseurl }} ./#other-projects">Other Sister Projects</a>
 									</li>
 								</ul>
-							</li>	
-							<li class="code-in-nav">
+							</li>
+							<li class="code-in-nav has-dropdown">
 								<a href="https://codein.withgoogle.com/organizations/fossasia/">
 									GCI
 								</a>
@@ -88,7 +88,7 @@
 										<a href="https://gci14.fossasia.org">FOSSASIA GCI 2014/15</a>
 									</li>
 								</ul>
-							</li>	
+							</li>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Please read and understand everything below
**Do not delete any text other than where you are instructed.**

**Students: If one of them is applicable to you. Please check it.**

Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.

- [x] Read and understood (see CONTRIBUTING.md)
- [x] Included a Preview link and screenshot showing after and before the changes.
- [ ] Images are `240 x 240` [w x h].
- [x] Included a description of change below.
- [x] Squashed the commits.

# Changes done in this Pull Request
- There was no drop down arrow with GCI text and icon, added it.
- https://ankurg22.github.io/gci17.fossasia.org/
- Fixes #954
