### PR TITLE
Reverted hover color on drop-down to gray

### DIFF
--- a/css/theme-red.css
+++ b/css/theme-red.css
@@ -1046,7 +1046,7 @@ nav.bg-dark .logo-dark {
   visibility: visible;
 }
 .menu > li > ul a:hover {
-  background-color: red;
+  background-color: gray;
   width: 100%;
 }
 .menu > li > ul > li:hover > ul,


### PR DESCRIPTION
Please read and understand everything below
**Do not delete any text other than where you are instructed.**

**Students: If one of them is applicable to you. Please check it.**

Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.

- [x] Read and understood (see CONTRIBUTING.md)
- [x] Included a Preview link and screenshot showing after and before the changes.
- [ ] Images are `240 x 240` [w x h].
- [x] Included a description of change below.
- [x] Squashed the commits.

# Changes done in this Pull Request
- Currently, the hover color was red. Since we are not following
FOSSASIA's standard so red didn't make any sense. So reverted it to
gray.
- https://ankurg22.github.io/gci17.fossasia.org/
- Fixes #971
